### PR TITLE
feat: implement bep-20 peer id convention

### DIFF
--- a/bittorrent-common/src/types.rs
+++ b/bittorrent-common/src/types.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand::{Rng, RngCore, distr::Alphanumeric};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct InfoHash([u8; 20]);
@@ -51,19 +51,19 @@ impl PeerID {
         Self(id)
     }
 
+    /// Generate a BEP 20 peer ID
+    /// (BEP 20)-[https://www.bittorrent.org/beps/bep_0020.html]
     pub fn generate() -> Self {
-        let mut rng = rand::rng();
+        const BEP20: &[u8] = b"-RS0000-"; // 8-byte prefix
         let mut id = [0u8; 20];
 
-        id[0] = b'r';
-        id[1] = b's';
-        id[2] = b'-';
+        // Copy prefix into the start of id
+        let o = BEP20.len();
+        id[..o].copy_from_slice(BEP20);
 
-        // Fill with random alphanumeric characters for better readability
-        for i in id.iter_mut().skip(3) {
-            // Generate random bytes in a readable ASCII range
-            *i = rng.random_range(48..126); // Numbers, letters, and some symbols
-        }
+        // Fill remaining bytes with random bytes
+        rand::rng().fill_bytes(&mut id[o..]);
+
         Self(id)
     }
 


### PR DESCRIPTION
**Description:**
This PR adds a BEP 20–compliant `PeerID` generator to the client. Key changes:

* Implements a fixed **client prefix (`-RS0000-`)** at the start of the 20-byte peer ID.
* Fills the remaining bytes with cryptographically **random data** for uniqueness.
* Ensures the **full peer ID is exactly 20 bytes**, matching the BEP 20 specification.
* Mirrors behavior from the Go reference client: copy prefix, then randomize remaining bytes.

**Usage Example:**

```rust
let peer_id = PeerID::generate();
println!("PeerID: {:?}", peer_id.as_bytes());
```

This makes the client fully compatible with trackers and peers that expect standard BEP 20 peer IDs.